### PR TITLE
Update conda dockerfiles to use conda-environment.yaml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,26 @@ config-datasets/*
 
 ### Python ###
 # Byte-compiled / optimized / DLL files
-__pycache__/
+
+__pycache__
 *.py[cod]
 *$py.class
+.Python
+env
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+.git
+.mypy_cache
+.pytest_cache
+.hypothesis
 
 
 ### IDEs ###
@@ -41,30 +58,6 @@ venv.bak/
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
 .python-version
-
-
-### Python related files/folders ###
-
-__pycache__
-*.pyc
-*.pyo
-*.pyd
-.Python
-env
-pip-log.txt
-pip-delete-this-directory.txt
-.tox
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.log
-.git
-.mypy_cache
-.pytest_cache
-.hypothesis
 
 
 ### Distribution / packaging ###

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
+
+### Work-in-progress workspace for creating the STAC collections ###
+
+# This could contain a lot of work-in-progress data from generating STAC collections.
+# Docker image should not contain those.
+config-datasets/*
+
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -19,6 +27,7 @@ __pycache__/
 
 
 ### Environments ###
+
 .env
 .venv
 env/
@@ -27,15 +36,39 @@ ENV/
 env.bak/
 venv.bak/
 
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
 .python-version
 
 
-### Other ###
+### Python related files/folders ###
 
-# Distribution / packaging
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+.git
+.mypy_cache
+.pytest_cache
+.hypothesis
+
+
+### Distribution / packaging ###
+
 .Python
 build/
 develop-eggs/
@@ -56,7 +89,8 @@ share/python-wheels/
 MANIFEST
 
 
-# Unit test / coverage reports
+### Unit test / coverage reports ###
+
 htmlcov/
 .tox/
 .nox/
@@ -71,6 +105,8 @@ coverage.xml
 .pytest_cache/
 cover/
 
+
+### Various Tooling ###
 
 # Sphinx documentation
 docs/_build/
@@ -98,18 +134,7 @@ dmypy.json
 .ruff_cache/
 
 
-# LSP config files
-# pyrightconfig.json
-
-
-# Having a .local folder that is ignored by git is often handy for files that you want
-# to keep near your code but that are not part of the git repo because they won't work for everyone.
-# For example your own configuration files for testing that will only work in your
-# own development environment.
-# Off course, you could also put them outside your git working dir, but sometimes
-# having everything inside the workspace makes things simpler.
-.local
-
+### Other ###
 
 # Sometimes test output from generating STAC collections goes here
 # Though we are avoiding that more and more now.
@@ -119,3 +144,13 @@ tmp/
 
 # statistics files for profiling performance, output of the cProfile module.
 *.stats
+
+
+# Same reason as in .gitignore:
+# This folder is intended as a place to put files that you do want to keep
+# close to your code but they should never go into git or a docker image.
+# You could have a directory structure where it lives in the parent dir next
+# to your git repository, but that can complicate thing in other ways.
+# It is going to happen anyway at some point, so it is better to give it
+# a safe place beforehand.
+.local

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,7 @@
   - [Goal: testing the requirements files and conda environment](#goal-testing-the-requirements-files-and-conda-environment)
   - [**NOT** a goal: these are not dockerfiles for production deployment](#not-a-goal-these-are-not-dockerfiles-for-production-deployment)
   - [Principle: Specify only direct dependencies, and let package manager resolve the rest](#principle-specify-only-direct-dependencies-and-let-package-manager-resolve-the-rest)
+    - [Why separate direct from fully resolved dependencies?](#why-separate-direct-from-fully-resolved-dependencies)
   - [Possible use in future: CI/testing/dev in docker container](#possible-use-in-future-citestingdev-in-docker-container)
 - [Contents: Three environments to verify](#contents-three-environments-to-verify)
 - [Usage: 1) How to build the Docker images](#usage-1-how-to-build-the-docker-images)
@@ -38,14 +39,17 @@ A production setup has different demands from what we want to achieve here. For 
 However, that is not at all what we want to achieve with the current requirements files and `conda-environment.yaml`. Here we deliberately specify only the dependencies that we depend on **directly**, and we are keeping it OS independent as well.
 Then we let the package manager resolve the other so-called "transitive" dependencies.
 
-This avoids problems when we want to upgrade our direct dependencies or when we want the environment to work on different operating systems. If there is no indication which are our direct dependencies, then a lot more dependencies might conflict with each other and we can not see which ones we can upgrade.
-This can be very cumbersome to figure out. Also on different OSs or different machines you may require some different packages because of OS-dependent packages. Troubleshooting all of this is a lot of hassle but we can avoid that hassle by keeping the list of direct dependencies separate from the fully resolved dependencies, that may be OS dependent.
-
 If you happen to know the way [pip-tools](https://pip-tools.readthedocs.io/en/latest/) works, then you could compare this way of working to specifying the `requirements.in` file that pip-compile fully resolves to `requirement.txt`. We are specifying and testing the first type of file here: `requirements.in`, not the requirement.txt.
 
 > - TODO: (1) Maybe rename the requirements files for clarity: extension `.in` instead of `.txt`
 > - TODO: (2) Decided if we want tooling to resolved full and locked dependencies, and which one: pip-tools, pip-env, poetry, or another,
 > - TODO: (3) Can Hatch already do the job for `todo (2)`?
+
+#### Why separate direct from fully resolved dependencies?
+
+This approach avoids problems when we want to upgrade our dependencies or when we want the environment to work on different operating systems. If there is no indication which are our direct dependencies, then a lot more dependencies might conflict with each other and we can not easily see which ones we can upgrade and which ones have to stay at a certain version. And that can be very cumbersome to figure out.
+
+Moreover, on different OSs you may also require different packages because some Python packages do depend on things that are OS-dependent (They require an package, or they rely on native libraries, etc.). Troubleshooting all of this can be a lot of hassle, but we can avoid that hassle by keeping the list of direct dependencies separate from the fully resolved dependencies, that may be OS dependent.
 
 ### Possible use in future: CI/testing/dev in docker container
 
@@ -54,7 +58,7 @@ We might be able to use it for CI / Jenkins in the near future.
 
 Further, this may be useful if you are on Windows or Mac, because the tool is currently only being used and tested on Linux and this would give you a Linux environment.
 
-Though for Windows, working in either a conda environment, or inside WSL, are another options and frankly that is less work than a Docker setup.
+Though for Windows, working in either a conda environment, or inside WSL, are alternatives and frankly those options require less work than a Docker setup.
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,6 +71,7 @@ docker run --rm -ti --entrypoint bash stac-catalog-builder-debianpython:latest
 Image name and tag: `stac-catalog-builder-miniconda:latest`
 
 A) Inside the the subdirectory `docker`
+
     ```bash
     docker build -t stac-catalog-builder-miniconda:latest -f miniconda.dockerfile ..
     ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,17 +1,36 @@
 # Dockerfiles for testing the package installation
 
-With some work you could use these for testing or even developing.
+First and foremost these dockerfiles are intended for testing the package installation, i.e.
+do the pip requirements files and the `conda-environment.yaml` work correctly.
 
-This may be useful if you are on Windows or Mac, because the tool is currently only being used and tested on Linux.
+The idea is that if the installation succeeds and the test suite with pytest passes, > Tthan the requirements / conda env should be good enough for development.
+This is not (yet) a production setup that should have locked down version to get reproducible builds.
 
+Compare this to using `requirements.in` with pip-tools/pip-compile to get a fully resolved requirement.txt.
+We are specifying and testing the first type of file here: `requirements.in`, not the requirement.txt.
+
+> - TODO: (1) Maybe rename the requirements files for clarity: extension `.in` instead of `.txt`
+> - TODO: (2) Decided if we want tooling to resolved full and locked dependencies, and which one: pip-tools, pip-env, poetry, or another,
+> - TODO: (3) Can Hatch already do the job for `todo (2)`?
+
+## Possible use in future: CI/testing/dev in docker container
+
+That said, with some work you could also use these containers for testing or even developing.
+We might be able to use it for CI / Jenkins in the near future.
+
+Further, this may be useful if you are on Windows or Mac, because the tool is currently only being used and tested on Linux and this would give you a Linux environment.
+
+Though for Windows, working in either a conda environment, or inside WSL, are another options and frankly that is less work than a Docker setup.
+
+## Three environments to verify
 
 There are three dockerfiles for three types of environments:
 
-- [debianpython.dockerfile](debianpython.dockerfile): Uses only pip in a Debian docker image.
+- [debianpython.dockerfile](debianpython.dockerfile): Uses only pip, in a Debian docker image.
 - [miniconda.dockerfile](miniconda.dockerfile): Installs the packages in miniconda, starting from the [continuumio/miniconda3 image](https://hub.docker.com/r/continuumio/miniconda3).
 - [miniforge.dockerfile](miniforge.dockerfile): Installs the packages in miniforge, the Open Source alternative to miniconda, and start from the [condaforge/miniforge3 docker image](https://hub.docker.com/r/condaforge/miniforge3)
 
-## How to build the images
+## How to build the Docker images
 
 ### Example for debianpython.dockerfile
 
@@ -62,7 +81,6 @@ Open a bash shell inside the running docker container:
 ```bash
 docker run --rm -ti --entrypoint bash stac-catalog-builder-debianpython:latest
 ```
-
 
 ## Examples for miniconda
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,45 @@
 # Dockerfiles for testing the package installation
 
+- [Rationale](#rationale)
+  - [Goal: testing the requirements files and conda environment](#goal-testing-the-requirements-files-and-conda-environment)
+  - [**NOT** a goal: these are not dockerfiles for production deployment](#not-a-goal-these-are-not-dockerfiles-for-production-deployment)
+  - [Principle: Specify only direct dependencies, and let package manager resolve the rest](#principle-specify-only-direct-dependencies-and-let-package-manager-resolve-the-rest)
+  - [Possible use in future: CI/testing/dev in docker container](#possible-use-in-future-citestingdev-in-docker-container)
+- [Contents: Three environments to verify](#contents-three-environments-to-verify)
+- [Usage: 1) How to build the Docker images](#usage-1-how-to-build-the-docker-images)
+  - [Example: build image for debianpython.dockerfile](#example-build-image-for-debianpythondockerfile)
+  - [Example: build image for miniconda](#example-build-image-for-miniconda)
+- [Usage: 2) How to run the docker container](#usage-2-how-to-run-the-docker-container)
+    - [Debian-Python: Run the tests with the Docker container](#debian-python-run-the-tests-with-the-docker-container)
+    - [miniconda: Run the tests with the Docker container](#miniconda-run-the-tests-with-the-docker-container)
+- [Usage: 3) run a bash shell in the container for troubleshooting](#usage-3-run-a-bash-shell-in-the-container-for-troubleshooting)
+  - [miniconda: Open a bash shell inside the running docker container](#miniconda-open-a-bash-shell-inside-the-running-docker-container)
+
+
+## Rationale
+
+### Goal: testing the requirements files and conda environment
+
 First and foremost these dockerfiles are intended for testing the package installation, i.e.
 do the pip requirements files and the `conda-environment.yaml` work correctly.
 
 The idea is that if the installation succeeds and the test suite with pytest passes, then the requirements / conda env should be good enough for development.
 
-This is not (yet) a production setup, because that environment should specify locked down versions for all dependencies in order to get reproducible builds.
+### **NOT** a goal: these are not dockerfiles for production deployment
 
-However, that is not what we want to achieve with the requirements files and `conda-environment.yaml`. Here we deliberately specify only the dependencies that we depend on **directly**, and we are keeping it OS independent as well.
+This **not** meant to be a production setup, as you would expect in a web application. Do not use it for that.
+
+Moreover, in principle this is a tool for a small set of users, who should be able to set this up. But if we do need something very reproducible, we could still add that setup later.
+
+### Principle: Specify only direct dependencies, and let package manager resolve the rest
+
+A production setup has different demands from what we want to achieve here. For production you should have  an environment that specifies the full versions for all dependencies in order to get reproducible builds. (Possibly even with some extra verifications such as hashes to know the package is the correct one, and that it has not been tampered with, for security)
+
+However, that is not at all what we want to achieve with the current requirements files and `conda-environment.yaml`. Here we deliberately specify only the dependencies that we depend on **directly**, and we are keeping it OS independent as well.
 Then we let the package manager resolve the other so-called "transitive" dependencies.
 
-This avoids that we have to figure out what dependencies are conflicting when we want to upgrade something, or why the environment can install on one OS or one machine but it breaks on another.
+This avoids problems when we want to upgrade our direct dependencies or when we want the environment to work on different operating systems. If there is no indication which are our direct dependencies, then a lot more dependencies might conflict with each other and we can not see which ones we can upgrade.
+This can be very cumbersome to figure out. Also on different OSs or different machines you may require some different packages because of OS-dependent packages. Troubleshooting all of this is a lot of hassle but we can avoid that hassle by keeping the list of direct dependencies separate from the fully resolved dependencies, that may be OS dependent.
 
 If you happen to know the way [pip-tools](https://pip-tools.readthedocs.io/en/latest/) works, then you could compare this way of working to specifying the `requirements.in` file that pip-compile fully resolves to `requirement.txt`. We are specifying and testing the first type of file here: `requirements.in`, not the requirement.txt.
 
@@ -18,7 +47,7 @@ If you happen to know the way [pip-tools](https://pip-tools.readthedocs.io/en/la
 > - TODO: (2) Decided if we want tooling to resolved full and locked dependencies, and which one: pip-tools, pip-env, poetry, or another,
 > - TODO: (3) Can Hatch already do the job for `todo (2)`?
 
-## Possible use in future: CI/testing/dev in docker container
+### Possible use in future: CI/testing/dev in docker container
 
 That said, with some work you could also use these containers for testing or even developing.
 We might be able to use it for CI / Jenkins in the near future.
@@ -27,7 +56,9 @@ Further, this may be useful if you are on Windows or Mac, because the tool is cu
 
 Though for Windows, working in either a conda environment, or inside WSL, are another options and frankly that is less work than a Docker setup.
 
-## Three environments to verify
+---
+
+## Contents: Three environments to verify
 
 There are three dockerfiles for three types of environments:
 
@@ -35,9 +66,11 @@ There are three dockerfiles for three types of environments:
 - [miniconda.dockerfile](miniconda.dockerfile): Installs the packages in miniconda, starting from the [continuumio/miniconda3 image](https://hub.docker.com/r/continuumio/miniconda3).
 - [miniforge.dockerfile](miniforge.dockerfile): Installs the packages in miniforge, the Open Source alternative to miniconda, and start from the [condaforge/miniforge3 docker image](https://hub.docker.com/r/condaforge/miniforge3)
 
-## How to build the Docker images
+---
 
-### Example for debianpython.dockerfile
+## Usage: 1) How to build the Docker images
+
+### Example: build image for debianpython.dockerfile
 
 You can run the command inside the folder `docker` or you can run a slightly
 different command in its parent folder, in other words in the root of your code repository.
@@ -70,26 +103,9 @@ B) In the root of your git repository:
     docker build -t stac-catalog-builder-debianpython:latest -f docker/debianpython.dockerfile .
     ```
 
-## How to run the docker container
+###  Example: build image for miniconda
 
-This runs the unit tests with pytest. If this succeeds your Docker environment should be OK.
-
-Example for the example above with debianpython.dockerfile, using the same image name+tag
-`stac-catalog-builder-debianpython:latest`.
-
-```bash
-docker run --rm -ti stac-catalog-builder-debianpython:latest
-```
-
-Open a bash shell inside the running docker container:
-
-```bash
-docker run --rm -ti --entrypoint bash stac-catalog-builder-debianpython:latest
-```
-
-## Examples for miniconda
-
-### Build the image for miniconda
+The commands are very similar to the debianpython.dockerfile but with a second example we can show what you need to change when you use a different docker file or docker image. The commands for miniforge are completely analogous.
 
 Image name and tag: `stac-catalog-builder-miniconda:latest`
 
@@ -107,11 +123,32 @@ B) In the root of your git repository:
     docker build -t stac-catalog-builder-miniconda:latest -f docker/miniconda.dockerfile .
     ```
 
-### miniconda: Run the tests with the Docker container
+## Usage: 2) How to run the docker container
+
+This runs the unit tests with pytest. If this succeeds your Docker environment should be OK.
+
+#### Debian-Python: Run the tests with the Docker container
+
+Example for the example above with debianpython.dockerfile, using the same image name+tag
+`stac-catalog-builder-debianpython:latest`.
+
+```bash
+docker run --rm -ti stac-catalog-builder-debianpython:latest
+```
+
+Open a bash shell inside the running docker container:
+
+```bash
+docker run --rm -ti --entrypoint bash stac-catalog-builder-debianpython:latest
+```
+
+#### miniconda: Run the tests with the Docker container
 
 ```shell
 docker run --rm -ti stac-catalog-builder-miniconda:latest
 ```
+
+## Usage: 3) run a bash shell in the container for troubleshooting
 
 ### miniconda: Open a bash shell inside the running docker container
 
@@ -128,6 +165,8 @@ docker run --rm -ti -v ${PWD}:/src --entrypoint bash stac-catalog-builder-minico
 ```
 
 In Powershell:
+
+Note that the the `-v ` option for the source of the bind volume has a different value in Powershell.
 
 ```powershell
 docker run --rm -ti -v ${pwd}:/src --entrypoint bash stac-catalog-builder-miniconda:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,11 +3,16 @@
 First and foremost these dockerfiles are intended for testing the package installation, i.e.
 do the pip requirements files and the `conda-environment.yaml` work correctly.
 
-The idea is that if the installation succeeds and the test suite with pytest passes, > Tthan the requirements / conda env should be good enough for development.
-This is not (yet) a production setup that should have locked down version to get reproducible builds.
+The idea is that if the installation succeeds and the test suite with pytest passes, then the requirements / conda env should be good enough for development.
 
-Compare this to using `requirements.in` with pip-tools/pip-compile to get a fully resolved requirement.txt.
-We are specifying and testing the first type of file here: `requirements.in`, not the requirement.txt.
+This is not (yet) a production setup, because that environment should specify locked down versions for all dependencies in order to get reproducible builds.
+
+However, that is not what we want to achieve with the requirements files and `conda-environment.yaml`. Here we deliberately specify only the dependencies that we depend on **directly**, and we are keeping it OS independent as well.
+Then we let the package manager resolve the other so-called "transitive" dependencies.
+
+This avoids that we have to figure out what dependencies are conflicting when we want to upgrade something, or why the environment can install on one OS or one machine but it breaks on another.
+
+If you happen to know the way [pip-tools](https://pip-tools.readthedocs.io/en/latest/) works, then you could compare this way of working to specifying the `requirements.in` file that pip-compile fully resolves to `requirement.txt`. We are specifying and testing the first type of file here: `requirements.in`, not the requirement.txt.
 
 > - TODO: (1) Maybe rename the requirements files for clarity: extension `.in` instead of `.txt`
 > - TODO: (2) Decided if we want tooling to resolved full and locked dependencies, and which one: pip-tools, pip-env, poetry, or another,

--- a/docker/miniconda.dockerfile
+++ b/docker/miniconda.dockerfile
@@ -15,11 +15,9 @@ ARG PYTHON_VERSION=3.11
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     mamba create --name testenv python=${PYTHON_VERSION}
 
-
-COPY requirements/ ${SRC_DIR}/requirements
-
+COPY conda-environment.yaml ${SRC_DIR}
 RUN --mount=type=cache,target=/var/cache/apt \
-    mamba run -n testenv python3 -m  pip install --no-cache-dir -r ${SRC_DIR}/requirements/requirements-dev.txt --extra-index-url https://artifactory.vgt.vito.be/artifactory/api/pypi/python-packages/simple
+    mamba env create -f conda-environment.yaml
 
 
 FROM dependencies as finalstage
@@ -27,7 +25,7 @@ FROM dependencies as finalstage
 COPY . ${SRC}
 
 RUN --mount=type=cache,target=/var/cache/apt \
-    mamba run -n testenv python3 -m pip install -e .
+    mamba run -n stac-catalog-builder python3 -m pip install -e .
 
-ENTRYPOINT ["mamba", "run", "-n", "testenv"]
+ENTRYPOINT ["mamba", "run", "-n", "stac-catalog-builder"]
 CMD ["pytest", "-ra", "-vv"]

--- a/docker/miniforge.dockerfile
+++ b/docker/miniforge.dockerfile
@@ -15,11 +15,9 @@ ARG PYTHON_VERSION=3.11
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     mamba create --name testenv python=${PYTHON_VERSION}
 
-
-COPY requirements/ ${SRC_DIR}/requirements
-
+COPY conda-environment.yaml ${SRC_DIR}
 RUN --mount=type=cache,target=/var/cache/apt \
-    mamba run -n testenv python3 -m  pip install --no-cache-dir -r ${SRC_DIR}/requirements/requirements-dev.txt --extra-index-url https://artifactory.vgt.vito.be/artifactory/api/pypi/python-packages/simple
+    mamba env create -f conda-environment.yaml
 
 
 FROM dependencies as finalstage
@@ -27,7 +25,7 @@ FROM dependencies as finalstage
 COPY . ${SRC}
 
 RUN --mount=type=cache,target=/var/cache/apt \
-    mamba run -n testenv python3 -m pip install -e .
+    mamba run -n stac-catalog-builder python3 -m pip install -e .
 
-ENTRYPOINT ["mamba", "run", "-n", "testenv"]
+ENTRYPOINT ["mamba", "run", "-n", "stac-catalog-builder"]
 CMD ["pytest", "-ra", "-vv"]

--- a/docker/miniforge.dockerfile
+++ b/docker/miniforge.dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3 as base
+FROM condaforge/miniforge3:23.11.0-0 as base
 
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     conda install --yes -c conda-forge mamba \


### PR DESCRIPTION
Now that we have a better file to set up a conda environment, the corresponding dockerfiles should use it to.

Also added a `.dockerignore` file to keep stuff out of the image that does not need to be there.