### PR TITLE
docs: add developer guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # STAC Catalog Builder
-- [STAC Catalog Builder](#stac-catalog-builder)
-  - [Setup - Installation](#setup---installation)
-  - [Running the Stacbuilder Tool](#running-the-stacbuilder-tool)
-
 
 This tool generates a STAC collection from a set of GeoTiff images.
 
@@ -13,9 +9,9 @@ It requires a some configuration for the fields we need to fill in, but the goal
 For now it only supports GeoTIFFs. For example, netCDF is not supported yet, because it can be a lot more complex to extract info from than GeoTIFF.
 We wanted to start with GeoTIFF and we can see about other needs later.
 
-- [Setup - Installation](docs/installation.md)
-- [How to run the STAC builder](#running-the-stacbuilder-tool)
-- [Goals and User Stories](docs/goals-and-user-stories.md): A longer explanation of the goals or use case for the STAC catalog builder.
+Support for uploading to a STAC API is in the making.
+
+See also: [Goals and User Stories](docs/goals-and-user-stories.md): A longer explanation of the goals or use case for the STAC catalog builder.
 
 ## Setup - Installation
 
@@ -24,3 +20,7 @@ See: [docs/installation.md](docs/installation.md)
 ## Running the Stacbuilder Tool
 
 See: [docs/how-to-run-stacbuilder.md](docs/how-to-run-stacbuilder.md)
+
+## Software Development Guidelines
+
+See [docs/developer-guidelines.md](docs/developer-guidelines.md)

--- a/docs/developer-guidelines.md
+++ b/docs/developer-guidelines.md
@@ -1,0 +1,45 @@
+# Software Development Guidelines
+
+The packaging is based on Hatch and Hatchling.
+
+[Hatch docs: https://hatch.pypa.io/](https://hatch.pypa.io/)
+
+## pre-commit
+
+This project uses [pre-commit](https://pre-commit.com/) and [ruff](https://docs.astral.sh/ruff/) to keep the coding style consistent and catch some common mistakes early.
+
+Pre-commit automates the linting and formatting tools and makes sure they are run before the code is committed into git. It is named after the pre-commit hook of git.
+
+### Install pre-commit
+
+```shell
+pre-commit install
+```
+
+## Build the Python wheel
+
+This commands builds the wheel, and also the source distribution.
+You can use the wheel to install the tool if you are not doing any development on it or if you want to containerize it.
+
+```shell
+hatch build
+```
+
+## Versioning
+
+The version number is stored in stacbuilder._version.py
+
+Update the version:
+You can either manually update the version in the file or use Hatch;
+
+You can update the version as described in the [Hatch docs about this topic](https://hatch.pypa.io/latest/version/#updating)
+
+Some examples:
+
+```shell
+hatch version "0.1.0"
+# Or
+hatch version minor
+# Or
+hatch version major,rc
+```


### PR DESCRIPTION
Added a documentation page for software development guidelines, for now with just some basic instructions.