### PR TITLE
fix: convert output_dir in build_collection from string to path when …

### DIFF
--- a/stacbuilder/builder.py
+++ b/stacbuilder/builder.py
@@ -984,11 +984,14 @@ class GeoTiffPipeline:
         Also we do not want to mix these (volatile) path settings with the
         stable/fixed settings in the general config file.
         """
+        if output_dir and not isinstance(output_dir, Path):
+            raise TypeError(f"Argument output_dir (if not None) should be of type Path, {type(output_dir)=}")
+
         pipeline = GeoTiffPipeline(None, None, None, None)
         pipeline.setup(
             collection_config=collection_config,
             file_coll_cfg=file_coll_cfg,
-            output_dir=output_dir.absolute() if output_dir else None,
+            output_dir=output_dir.expanduser().absolute() if output_dir else None,
             overwrite=overwrite,
         )
         return pipeline

--- a/stacbuilder/commandapi.py
+++ b/stacbuilder/commandapi.py
@@ -42,6 +42,10 @@ def build_collection(
     collection_config_path = Path(collection_config_path).expanduser().absolute()
     coll_cfg = CollectionConfig.from_json_file(collection_config_path)
     file_coll_cfg = FileCollectorConfig(input_dir=input_dir, glob=glob, max_files=max_files)
+
+    if output_dir and not isinstance(output_dir, Path):
+        output_dir = Path(output_dir).expanduser().absolute()
+
     pipeline = GeoTiffPipeline.from_config(
         collection_config=coll_cfg,
         file_coll_cfg=file_coll_cfg,


### PR DESCRIPTION
Fix: for a small bug: convert output_dir in build_collection from string to path when it comes from the CLI.

When using the CLI command "build" the output directory was passed as a string, but the build_collection method in commandapi actually expects a Path. And because it tries to expand that path to an absolute path we had an error.

Added the conversion, and a check for the correct type, deeper down the code where it really must be a Path.
For consistency, and just in case, also added expanduser() , so people can use the `~` and be sure it works.
