### PR TITLE
Fix Issue #22 build_grouped_collections should save each collection t…

### DIFF
--- a/stacbuilder/builder.py
+++ b/stacbuilder/builder.py
@@ -800,7 +800,6 @@ class AssetMetadataPipeline:
         else:
             self._collection_dir = self._output_base_dir
 
-        self._collection_dir = self._output_base_dir
         self._collection_builder = STACCollectionBuilder(
             collection_config=self._collection_config,
             overwrite=self._overwrite,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -206,10 +206,16 @@ class TestGeoTiffPipeline:
         assert pipeline.collection_groups is not None
         assert pipeline.collection is None
 
+        # Verify that each collection is written to its own separate file. (i.e. all paths are unique)
+        collection_files = set(coll.self_href for coll in pipeline.collection_groups.values())
+        assert len(collection_files) == len(pipeline.collection_groups)
+
         for coll in pipeline.collection_groups.values():
+            # Each collection file must effectively exist.
             coll_path = Path(coll.self_href)
             coll_path.exists()
 
+            # Each collection must be valid.
             collection = Collection.from_file(coll_path)
             collection.validate_all()
 


### PR DESCRIPTION
## Fix Issue #22 build_grouped_collections should save each collection to its own file.

Also extended a unit test to catch this error:
Namely, when we use grouped collections then the collections must have different paths.