### PR TITLE
Removed unwanted and conflicting dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   "pytest",
   "yarl==1.9.*",
   "universal_pathlib",
-  "s3fs>=2025.3.2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
s3fs package is not really needed as it is already installed by fsspec. The version specified also conflicts with fsspec due to s3fs being new and fsspec being old.