### PR TITLE
Avoid changing a throwaway copy of an object.

### DIFF
--- a/stacbuilder/config.py
+++ b/stacbuilder/config.py
@@ -94,7 +94,7 @@ class EOBandConfig(BaseModel):
         if not ext.bands:
             ext.apply(bands=[eo_band])
         else:
-            ext.bands.append(eo_band)
+            ext.bands = ext.bands.append(eo_band)
 
 
 class SamplingType(enum.StrEnum):


### PR DESCRIPTION
Fixes https://github.com/VitoTAP/stac-catalog-builder/issues/76