### PR TITLE
vici ndvi archive stac

### DIFF
--- a/configs-datasets/vici/archive/config.json
+++ b/configs-datasets/vici/archive/config.json
@@ -1,0 +1,82 @@
+{
+    "collection_id": "ndvi_archive",
+    "title": "VICI NDVI Archive",
+    "description": "Archival data required to compute the VICI drought index. The collection contains four layers with 36 timesteps each (one for each dekad in a year) covering Ethiopia, Mali, Mozambique, and Somalia. Layers include NDVI adjustments, 5th/15th percentiles, and seasonality masks.",
+    "instruments": [],
+    "keywords": [],
+    "mission": [],
+    "platform": [],
+    "providers": [
+        {
+            "name": "VITO",
+            "roles": [
+                "licensor",
+                "processor",
+                "producer"
+            ],
+            "url": "https://remotesensing.vito.be/"
+        }
+    ],
+    "layout_strategy_item_template": "${collection}",
+    "input_path_parser": {
+        "classname": "DefaultInputPathParser",
+        "parameters": {
+            "regex_pattern": "(?P<country>Ethiopia|Mali|Mozambique|Somalia)/(?P<asset_type>percentiles5|percentiles15|seasons_dekad|zone_adjust)_(?P<month>\\d{2})(?P<day>\\d{2})(?:\\.mpr)?\\.tif$",
+            "period": "daily",
+            "fixed_values": {
+                "year": 1970,
+                "item_id":  "{country}_{month}{day}"
+            }
+        }
+    },
+    "item_assets": {
+        "percentiles5": {
+            "title": "percentiles5",
+            "description": "5th percentiles computed on 2000-2019 adjusted NDVI timeseries",
+            "eo_bands": [
+                {
+                    "name": "percentiles5",
+                    "description": "5th percentiles computed on 2000-2019 adjusted NDVI timeseries",
+                    "data_type": "ubit8",
+                    "spatial_resolution": 100
+                }
+            ]
+        },
+        "percentiles15": {
+            "title": "percentiles15",
+            "description": "15th percentiles computed on 2000-2019 adjusted NDVI timeseries",
+            "eo_bands": [
+                {
+                    "name": "percentiles15",
+                    "description": "15th percentiles computed on 2000-2019 adjusted NDVI timeseries",
+                    "data_type": "ubit8",
+                    "spatial_resolution": 100
+                }
+            ]
+        },
+        "seasons_dekad": {
+            "title": "seasons_dekad",
+            "description": "Seasonality mask: 1 = in season, 0 = out of season",
+            "eo_bands": [
+                {
+                    "name": "seasons_dekad",
+                    "description": "Seasonality mask: 1 = in season, 0 = out of season",
+                    "data_type": "ubit8",
+                    "spatial_resolution": 100
+                }
+            ]
+        },
+        "zone_adjust": {
+            "title": "zone_adjust",
+            "description": "NDVI adjustments computed per zone",
+            "eo_bands": [
+                {
+                    "name": "zone_adjust",
+                    "description": "NDVI adjustments computed per zone",
+                    "data_type": "int16",
+                    "spatial_resolution": 100
+                }
+            ]
+        }
+    }
+}

--- a/configs-datasets/vici/archive/workflow.py
+++ b/configs-datasets/vici/archive/workflow.py
@@ -21,9 +21,9 @@ collection_config_path = current_dir / "config.json"
 assert collection_config_path.exists(), f"Collection config file not found at {collection_config_path}"
 
 # Input Paths
-tiff_input_path = current_dir   
-tiffs_glob = "*/*.tif"         
-data_path = f"/data/open/vici/archive"
+tiff_input_path = current_dir
+tiffs_glob = "*/*.tif"
+data_path = "/data/open/vici/archive"
 data_subpath = "/".join(data_path.split("/")[-2:])
 # Output Paths
 output_path = current_dir / "results" / catalog_version
@@ -34,7 +34,6 @@ input_files = list_input_files(glob=tiffs_glob, input_dir=tiff_input_path, max_f
 print(f"Found {len(input_files)} input files. 10 first files:")
 for i in input_files[:10]:
     print(i)
-
 
 
 # list meta data
@@ -51,20 +50,17 @@ def postprocess_item(item: pystac.Item) -> pystac.Item:
     for asset_name, asset_metadata in item.assets.items():
         # Extract filename from metadata.href instead of using asset_name directly
         full_filename = os.path.basename(asset_metadata.href)  # Extracts 'percentiles15_0101.tif'
-        
+
         # Construct the correct local path
         # Add the alternate field to each asset
         # get country from path
         country = Path(asset_metadata.href).parent.name
         asset_metadata.href = f"https://services.terrascope.be/download/open/{data_subpath}/{country}/{full_filename}"
-        
-        asset_metadata.extra_fields["alternate"] = {
-            "local": {
-                "href": f"{data_path}/{country}/{full_filename}" 
-            }
-        }
+
+        asset_metadata.extra_fields["alternate"] = {"local": {"href": f"{data_path}/{country}/{full_filename}"}}
         item.properties["country"] = country
     return item
+
 
 # list items
 stac_items, failed_files = list_stac_items(
@@ -79,9 +75,7 @@ if failed_files:
     print(f"Failed files: {failed_files}")
 
 if not stac_items:
-    raise RuntimeError(
-        "No STAC items created — check regex in config.json and folder structure"
-    )
+    raise RuntimeError("No STAC items created — check regex in config.json and folder structure")
 
 # build collection
 build_collection(
@@ -100,9 +94,7 @@ if collection_file.exists():
     validate_collection(collection_file=collection_file)
     print("Collection validation complete.")
 else:
-    raise FileNotFoundError(
-        f"collection.json not found at {collection_file}. Build likely failed."
-    )
+    raise FileNotFoundError(f"collection.json not found at {collection_file}. Build likely failed.")
 
 
 auth_settings = AuthSettings(

--- a/configs-datasets/vici/archive/workflow.py
+++ b/configs-datasets/vici/archive/workflow.py
@@ -1,0 +1,128 @@
+import pprint
+from getpass import getpass
+from pathlib import Path
+import os
+import pystac
+
+from stacbuilder import (
+    build_collection,
+    list_asset_metadata,
+    list_input_files,
+    list_stac_items,
+    upload_to_stac_api,
+    validate_collection,
+)
+from stacbuilder.stacapi.config import AuthSettings, Settings
+
+current_dir = Path(__file__).parent.resolve()
+# Collection configuration
+catalog_version = "v1.0.0"
+collection_config_path = current_dir / "config.json"
+assert collection_config_path.exists(), f"Collection config file not found at {collection_config_path}"
+
+# Input Paths
+tiff_input_path = current_dir   
+tiffs_glob = "*/*.tif"         
+data_path = f"/data/open/vici/archive"
+data_subpath = "/".join(data_path.split("/")[-2:])
+# Output Paths
+output_path = current_dir / "results" / catalog_version
+
+
+# list input files
+input_files = list_input_files(glob=tiffs_glob, input_dir=tiff_input_path, max_files=None)
+print(f"Found {len(input_files)} input files. 10 first files:")
+for i in input_files[:10]:
+    print(i)
+
+
+
+# list meta data
+asset_metadata = list_asset_metadata(
+    collection_config_path=collection_config_path, glob=tiffs_glob, input_dir=tiff_input_path, max_files=1
+)
+for k in asset_metadata:
+    pprint.pprint(k.to_dict())
+
+
+def postprocess_item(item: pystac.Item) -> pystac.Item:
+    # Example postprocessing: add a custom property to the item
+
+    for asset_name, asset_metadata in item.assets.items():
+        # Extract filename from metadata.href instead of using asset_name directly
+        full_filename = os.path.basename(asset_metadata.href)  # Extracts 'percentiles15_0101.tif'
+        
+        # Construct the correct local path
+        # Add the alternate field to each asset
+        # get country from path
+        country = Path(asset_metadata.href).parent.name
+        asset_metadata.href = f"https://services.terrascope.be/download/open/{data_subpath}/{country}/{full_filename}"
+        
+        asset_metadata.extra_fields["alternate"] = {
+            "local": {
+                "href": f"{data_path}/{country}/{full_filename}" 
+            }
+        }
+        item.properties["country"] = country
+    return item
+
+# list items
+stac_items, failed_files = list_stac_items(
+    collection_config_path=collection_config_path,
+    glob=tiffs_glob,
+    input_dir=tiff_input_path,
+    max_files=1000,
+    item_postprocessor=postprocess_item,
+)
+print(f"Found {len(stac_items)} STAC items")
+if failed_files:
+    print(f"Failed files: {failed_files}")
+
+if not stac_items:
+    raise RuntimeError(
+        "No STAC items created — check regex in config.json and folder structure"
+    )
+
+# build collection
+build_collection(
+    collection_config_path=collection_config_path,
+    glob=tiffs_glob,
+    input_dir=tiff_input_path,
+    output_dir=output_path,
+    item_postprocessor=postprocess_item,
+    link_items=False,
+)
+
+collection_file = output_path.parent / "collection.json"
+
+
+if collection_file.exists():
+    validate_collection(collection_file=collection_file)
+    print("Collection validation complete.")
+else:
+    raise FileNotFoundError(
+        f"collection.json not found at {collection_file}. Build likely failed."
+    )
+
+
+auth_settings = AuthSettings(
+    enabled=True,
+    interactive=False,
+    token_url="https://sso.terrascope.be/auth/realms/terrascope/protocol/openid-connect/token",
+    authorization_url="https://sso.terrascope.be/auth/realms/terrascope/protocol/openid-connect/auth",
+    client_id="terracatalogueclient",
+    username=input("Enter username for STAC API: "),
+    password=getpass("Enter password for STAC API: "),
+)
+settings = Settings(
+    auth=auth_settings,
+    stac_api_url="https://stac.openeo.vito.be/",
+    collection_auth_info={"_auth": {"read": ["anonymous"], "write": ["stac-openeo-admin", "stac-openeo-editor"]}},
+    bulk_size=1000,
+)
+
+upload_to_stac_api(
+    collection_path=collection_file,
+    settings=settings,
+)
+print("Done uploading collection to STAC API")

--- a/configs-datasets/vici/archive/workflow.py
+++ b/configs-datasets/vici/archive/workflow.py
@@ -1,7 +1,8 @@
+import os
 import pprint
 from getpass import getpass
 from pathlib import Path
-import os
+
 import pystac
 
 from stacbuilder import (


### PR DESCRIPTION
Added a new stac collection for Vici NDVI archive.

The difference in this approach compared to the general working method of the stac-builder is that it includes TIF files in separate folders. 

stac link: https://[stac.openeo.vito.be/collections/ndvi_archive](https://stac.openeo.vito.be/collections/ndvi_archive)